### PR TITLE
Add an uninstallation page.

### DIFF
--- a/chrome/_locales/en/messages.json
+++ b/chrome/_locales/en/messages.json
@@ -7,6 +7,16 @@
     "message": "Permanently opts your browser out of online ad personalization via cookies.",
     "description":  "The extension's short description that appears on the web store and `chrome://extensions`"
   },
+  "uninstall_button": {
+    "message": "Uninstall $name$",
+    "description": "The label of a button that uninstalls the extension.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
   "learnmore": {
     "message": "Learn more",
     "description": ""

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -19,6 +19,9 @@
         "background.js"
       ]
     },
+    "web_accessible_resources": [
+      "uninstall.html"
+    ],
     "permissions": [
       "notifications",
       "storage",

--- a/chrome/uninstall.html
+++ b/chrome/uninstall.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="uninstall.js">Keep My Opt-Outs</script>
+    <script src="uninstall.js"></script>
     <title></title>
   </head>
   <body>
-    <button id="uninstall">Uninstall Keep My Opt-Outs</button>
+    <button id="uninstall"></button>
   </body>
 </html>
 

--- a/chrome/uninstall.html
+++ b/chrome/uninstall.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="uninstall.js"></script>
+    <title></title>
+  </head>
+  <body>
+  </body>
+</html>
+

--- a/chrome/uninstall.html
+++ b/chrome/uninstall.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="uninstall.js"></script>
+    <meta charset="utf-8">
+    <script src="uninstall.js">Keep My Opt-Outs</script>
     <title></title>
   </head>
   <body>
-    <button id="uninstall">Uninstall</button>
+    <button id="uninstall">Uninstall Keep My Opt-Outs</button>
   </body>
 </html>
 

--- a/chrome/uninstall.html
+++ b/chrome/uninstall.html
@@ -5,6 +5,7 @@
     <title></title>
   </head>
   <body>
+    <button id="uninstall">Uninstall</button>
   </body>
 </html>
 

--- a/chrome/uninstall.js
+++ b/chrome/uninstall.js
@@ -20,7 +20,14 @@
  */
 
 
-document.getElementById('uninstall').addEventListener("click", function() {
-  chrome.management.uninstallSelf();
+window.addEventListener("load", function() {
+  var title = chrome.i18n.getMessage("extension_name");
+  var button = document.getElementById('uninstall');
+
+  document.title = title;
+  button.innerText = chrome.i18n.getMessage("uninstall_button", title);
+  button.addEventListener("click", function() {
+    chrome.management.uninstallSelf();
+  });
 });
 

--- a/chrome/uninstall.js
+++ b/chrome/uninstall.js
@@ -1,0 +1,26 @@
+// Copyright 2015 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/**
+ * @fileoverview This file is linked to uninstall.html, a page that can be
+ * pointed to from a Help Center article and will uninstall the extension
+ * when opened.
+ */
+
+
+window.addEventListener("load", function() {
+  chrome.management.uninstallSelf();
+});
+

--- a/chrome/uninstall.js
+++ b/chrome/uninstall.js
@@ -21,11 +21,11 @@
 
 
 window.addEventListener("load", function() {
-  var title = chrome.i18n.getMessage("extension_name");
+  var extensionName = chrome.i18n.getMessage("extension_name");
   var button = document.getElementById('uninstall');
 
-  document.title = title;
-  button.innerText = chrome.i18n.getMessage("uninstall_button", title);
+  document.title = extensionName;
+  button.innerText = chrome.i18n.getMessage("uninstall_button", extensionName);
   button.addEventListener("click", function() {
     chrome.management.uninstallSelf();
   });

--- a/chrome/uninstall.js
+++ b/chrome/uninstall.js
@@ -15,12 +15,12 @@
 
 /**
  * @fileoverview This file is linked to uninstall.html, a page that can be
- * pointed to from a Help Center article and will uninstall the extension
- * when opened.
+ * pointed to from a Help Center article and will allow the user to uninstall
+ * the extension.
  */
 
 
-window.addEventListener("load", function() {
+document.getElementById('uninstall').addEventListener("click", function() {
   chrome.management.uninstallSelf();
 });
 


### PR DESCRIPTION
When chrome-extension://<id>/uninstall.html is opened, it will uninstall the extension. This can be used as an uninstallation link from a Help Center article.