### PR TITLE
Return to the notification mechanism.

### DIFF
--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -36,32 +36,13 @@ Sunset.start_ = new Date();  // TBD
 
 
 /**
- * The hard deadline date of the deprecation phase.
- *
- * @type {Date}
- * @private
- */
-Sunset.deadline_ = new Date();  // TBD
-
-
-/**
- * The maximum number of days when the extension can be running before
- * it is automatically uninstalled.
- *
- * @type {Number}
- * @private
- */
-Sunset.max_uptime_ = 30;
-
-
-/**
  * Offsets of the notifications in days from the starting date.
  *
  * @type {Array<Number>}
  * @private
  */
 Sunset.timeline_offsets_ = [
-  7,
+  0,
   14,
   28,
   29
@@ -156,17 +137,6 @@ Sunset.showNotification_ = function(index) {
 
 
 /**
- * Opens a new tab with more information.
- * @private
- */
-Sunset.showLandingPage_ = function(notificationId) {
-  // We pass the notification index to message.html, so that the correct
-  // message content is loaded.
-  chrome.tabs.create({"url": "message.html#" + notificationId});
-}
-
-
-/**
  * Shows a help center article about this extension.
  * @private
  */
@@ -182,59 +152,12 @@ Sunset.showArticle_ = function() {
 
 
 /**
- * Runs periodically to check if the extension has been running for another
- * day. If so, it decreases the TTL. When TTL reaches zero, the extension
- * is automatically uninstalled.
- * @private
- */
-Sunset.heartbeat_ = function() {
-  // If we're past the hard deadline, just uninstall the extension.
-  var today = new Date();
-  today.setHours(0, 0, 0, 0);
-  if (today >= Sunset.deadline_) {
-    chrome.management.uninstallSelf();
-    return;
-  }
-
-  // Otherwise, check if a whole day has passed and decrease the TTL.
-  chrome.storage.sync.get(null, function(data) {
-    // Read the remaining TTL and last uptime date from the storage.
-    var ttl = parseInt(data.ttl, 10);
-    var last_date = new Date(data.date);
-
-    if (isNaN(ttl) || ttl >= Sunset.max_uptime_)
-      ttl = Sunset.max_uptime_;
-
-    if (!last_date.getTime())
-      last_date = new Date();
-
-    // If a day has passed, decrease the TTL. When TTL reaches zero,
-    // uninstall the extension.
-    last_date.setHours(0, 0, 0, 0);
-    if (today > last_date)
-      --ttl;
-
-    if (ttl <= 0) {
-      chrome.management.uninstallSelf();
-      return;
-    }
-
-    // Write the new TTL and date.
-    chrome.storage.sync.set({
-      "ttl": ttl,
-      "date": today.toString()
-    });
-  });
-}
-
-
-/**
  * Triggers a loop that tests if conditions were met to show the message.
  */
 Sunset.run = function() {
   chrome.browserAction.onClicked.addListener(Sunset.showArticle_);
-  chrome.notifications.onButtonClicked.addListener(Sunset.showLandingPage_);
-  chrome.alarms.onAlarm.addListener(Sunset.heartbeat_);
+  chrome.notifications.onButtonClicked.addListener(Sunset.showArticle_);
+  chrome.alarms.onAlarm.addListener(Sunset.maybeShowNotification_);
   chrome.alarms.create(null, {
       "delayInMinutes": 1,        // In a minute.
       "periodInMinutes": 12 * 60  // Twice per day.


### PR DESCRIPTION
Use the scheduling system of the notifications (original design), but to open a help center article instead of an extension-hosted landing page (second design).

Remove the unneeded class members from sunset.js (i.e. parts of both designs that will not be used).