### PR TITLE
Remove the minimal offset mechanism.

### DIFF
--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -40,15 +40,6 @@ Sunset.timeline_offsets_ = [
 
 
 /**
- * The minimum offset in days between two subsequent notifications.
- *
- * @type {Number}
- * @private
- */
-Sunset.minimum_offset_ = 7;
-
-
-/**
  * The link to the Chrome Help Center article.
  *
  * @type {String}
@@ -62,12 +53,11 @@ Sunset.article_url_ = "https://support.google.com/chrome_webstore/?p=keep_my_opt
  *
  * @param {Date} start The starting date for the deprecation timeline.
  * @param {Date} now The current date.
- * @param {Date} previous The date on which a notification was previously displayed.
  * @param {number} index The index of the upcoming notification.
  *
  * return {boolean} True if a notification should be shown.
  */
-Sunset.shouldShowNotification_ = function(start, now, previous, index) {
+Sunset.shouldShowNotification_ = function(start, now, index) {
     if (!index || index >= Sunset.timeline_offsets_.length)
       return true;
 
@@ -75,16 +65,13 @@ Sunset.shouldShowNotification_ = function(start, now, previous, index) {
     next_scheduled_notification.setDate(
         next_scheduled_notification.getDate() + Sunset.timeline_offsets_[index]);
 
-    var minimum_offset = new Date(previous);
-    minimum_offset.setDate(
-        minimum_offset.getDate() + Sunset.minimum_offset_);
-
-    return now >= next_scheduled_notification && now >= minimum_offset;
+    return now >= next_scheduled_notification;
 };
 
 
 /**
- * Shows a notification if enough time has passed since the previous one.
+ * Shows a notification if enough time has passed since the beginning
+ * of the sunset phase.
  *
  * @private
  */
@@ -95,24 +82,20 @@ Sunset.maybeShowNotification_ = function() {
     if (data.start != starting_date.toString())
       chrome.storage.sync.set({ "start": starting_date.toString() });
 
-    // Read the index of the notification to be shown and the date when
-    // the previous notification was shown.
+    // Read the index of the notification to be shown.
     var index = parseInt(data.index, 10);
-    var most_recent_notification = new Date(data.date);
 
     // Reset the index if the stored data are invalid or not present.
     if (isNaN(index) || index < 0 ||
-        index >= Sunset.timeline_offsets_.length ||
-        !most_recent_notification.getTime()) {
+        index >= Sunset.timeline_offsets_.length) {
       index = 0;
     }
 
     // Trigger notification if we have reached the date suggested
-    // by the timeline and if enough time has passed since the previous
-    // one was shown. These checks are not required for the first notification.
+    // by the timeline. This check is not required for the first notification.
     var now = new Date();
 
-    if (Sunset.shouldShowNotification_(starting_date, now, most_recent_notification, index))
+    if (Sunset.shouldShowNotification_(starting_date, now, index))
       Sunset.showNotification_(index);
   });
 };
@@ -144,8 +127,7 @@ Sunset.showNotification_ = function(index) {
 
   // Save the state.
   chrome.storage.sync.set({
-    "index": index + 1,
-    "date": new Date().toString()
+    "index": index + 1
   });
 }
 

--- a/chrome/test/sunset-test.js
+++ b/chrome/test/sunset-test.js
@@ -14,17 +14,16 @@ function incrementDate(d) {
 test(function () {
   // Just installed:
   var start = new Date("2015-06-01 12:00 GMT");
-  assert_true(Sunset.shouldShowNotification_(start, start, new Date(null), 0));
-  assert_true(Sunset.shouldShowNotification_(start, start, start, 0));
+  assert_true(Sunset.shouldShowNotification_(start, start, 0));
 
   // Subsequent Days:
   var current = new Date("2015-06-01 12:01 GMT");
   for (var i = 1; i < 100; i++) {
     current = incrementDate(current);
-    assert_true(Sunset.shouldShowNotification_(start, current, start, 0));
-    assert_equals(i >= Sunset.timeline_offsets_[1], Sunset.shouldShowNotification_(start, current, start, 1));
-    assert_equals(i >= Sunset.timeline_offsets_[2], Sunset.shouldShowNotification_(start, current, start, 2));
-    assert_true(Sunset.shouldShowNotification_(start, current, start, 3));
+    assert_true(Sunset.shouldShowNotification_(start, current, 0));
+    assert_equals(i >= Sunset.timeline_offsets_[1], Sunset.shouldShowNotification_(start, current, 1));
+    assert_equals(i >= Sunset.timeline_offsets_[2], Sunset.shouldShowNotification_(start, current, 2));
+    assert_true(Sunset.shouldShowNotification_(start, current, 3));
   }
 }, "Sanity-check shouldShowNotification_");
 
@@ -33,7 +32,7 @@ test(function () {
 
   var before = new Date(start);
   before.setSeconds(before.getSeconds() - 1);
-  assert_false(Sunset.shouldShowNotification_(start, before, start, 1));
+  assert_false(Sunset.shouldShowNotification_(start, before, 1));
 
 
   // Increment to exactly the next transition point:
@@ -41,8 +40,8 @@ test(function () {
   for (var i = 0; i < Sunset.timeline_offsets_[1]; i++)
     current = incrementDate(current);
 
-  assert_true(Sunset.shouldShowNotification_(start, current, start, 1));
+  assert_true(Sunset.shouldShowNotification_(start, current, 1));
 
   current.setSeconds(current.getSeconds() - 1);
-  assert_false(Sunset.shouldShowNotification_(start, current, start, 1));
+  assert_false(Sunset.shouldShowNotification_(start, current, 1));
 }, "Edge-cases for shouldShowNotification_");

--- a/chrome/test/sunset-test.js
+++ b/chrome/test/sunset-test.js
@@ -12,6 +12,8 @@ function incrementDate(d) {
 }
 
 test(function () {
+  assert_false(Sunset.acceleratedTimeline_);
+
   // Just installed:
   var start = new Date("2015-06-01 12:00 GMT");
   assert_true(Sunset.shouldShowNotification_(start, start, 0));
@@ -28,6 +30,8 @@ test(function () {
 }, "Sanity-check shouldShowNotification_");
 
 test(function () {
+  assert_false(Sunset.acceleratedTimeline_);
+
   var start = new Date("2015-06-01 12:00 GMT");
 
   var before = new Date(start);


### PR DESCRIPTION
Since the starting date is variable and the third notification (i.e. the uninstallation) should not be offset by more than one day, we no longer need the minimal offset mechanism.