### PR TITLE
Update the translations.

### DIFF
--- a/chrome/_locales/es_419/messages.json
+++ b/chrome/_locales/es_419/messages.json
@@ -1,1 +1,48 @@
-{"extension_name":{"message":"Mantener mis opciones de exclusi\u00f3n"},"extension_description":{"message":"Excluye permanentemente tu navegador de la personalizaci\u00f3n de anuncios en l\u00ednea a trav\u00e9s de cookies."}}
+{
+  "extension_name": {
+    "message": "OBSOLETO: Inhabilitar personalización",
+    "description": "The extension's name."
+  },
+  "extension_description": {
+    "message": "Novedad importante",
+    "description": "The extension's short description that appears on the web store and `chrome://extensions`"
+  },
+  "uninstall_button": {
+    "message": "Desinstalar $name$",
+    "description": "The label of a button that uninstalls the extension.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "learnmore": {
+    "message": "Más información sobre cómo actualizar la extensión",
+    "description": "Link text for the deprecation notification."
+  },
+  "kmoo": {
+    "message": "Inhabilitar personalización",
+    "description": "The title of the extension (without 'DEPRECATED')"
+  },
+  "message0": {
+    "message": "$name$ se eliminará en 14 días.",
+    "description": "Body of the first deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "message1": {
+    "message": "$name$ se eliminará en breve.",
+    "description": "Body of the second deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  }
+}

--- a/chrome/_locales/he/messages.json
+++ b/chrome/_locales/he/messages.json
@@ -1,1 +1,48 @@
-{"extension_name":{"message":"\u05e9\u05de\u05d5\u05e8 \u05d0\u05ea \u05d1\u05d9\u05d8\u05d5\u05dc\u05d9 \u05d4\u05d4\u05e6\u05d8\u05e8\u05e4\u05d5\u05ea \u05e9\u05dc\u05d9"},"extension_description":{"message":"\u05de\u05d1\u05d8\u05dc \u05d0\u05ea \u05d4\u05e6\u05d8\u05e8\u05e4\u05d5\u05ea \u05d4\u05d3\u05e4\u05d3\u05e4\u05df \u05e9\u05dc\u05da \u05dc\u05d4\u05ea\u05d0\u05de\u05d4 \u05d0\u05d9\u05e9\u05d9\u05ea \u05e9\u05dc \u05e4\u05e8\u05e1\u05d5\u05de\u05d5\u05ea \u05de\u05e7\u05d5\u05d5\u05e0\u05d5\u05ea \u05d1\u05d0\u05de\u05e6\u05e2\u05d5\u05ea \u05e7\u05d5\u05d1\u05e6\u05d9 cookie."}}
+{
+  "extension_name": {
+    "message": "יצא משימוש: שמור את ביטולי ההצטרפות שלי",
+    "description": "The extension's name."
+  },
+  "extension_description": {
+    "message": "עדכון חשוב",
+    "description": "The extension's short description that appears on the web store and `chrome://extensions`"
+  },
+  "uninstall_button": {
+    "message": "הסר את ההתקנה של $name$",
+    "description": "The label of a button that uninstalls the extension.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "learnmore": {
+    "message": "קרא מידע נוסף כיצד לשדרג",
+    "description": "Link text for the deprecation notification."
+  },
+  "kmoo": {
+    "message": "שמור את ביטולי ההצטרפות שלי",
+    "description": "The title of the extension (without 'DEPRECATED')"
+  },
+  "message0": {
+    "message": "$name$ יוסר בתוך 14 ימים.",
+    "description": "Body of the first deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "message1": {
+    "message": "$name$ יוסר בקרוב.",
+    "description": "Body of the second deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  }
+}

--- a/chrome/_locales/sk/messages.json
+++ b/chrome/_locales/sk/messages.json
@@ -1,1 +1,48 @@
-{"extension_name":{"message":"Zachova\u0165 moje zru\u0161enia"},"extension_description":{"message":"Natrvalo v prehliada\u010di zru\u0161\u00ed prisp\u00f4sobovania online rekl\u00e1m prostredn\u00edctvom s\u00faborov cookie."}}
+{
+  "extension_name": {
+    "message": "UKONČENIE PODPORY: Zachovať odhlásenie",
+    "description": "The extension's name."
+  },
+  "extension_description": {
+    "message": "Dôležitá aktualizácia",
+    "description": "The extension's short description that appears on the web store and `chrome://extensions`"
+  },
+  "uninstall_button": {
+    "message": "Odinštalovať rozšírenie $name$",
+    "description": "The label of a button that uninstalls the extension.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "learnmore": {
+    "message": "Ďalšie informácie o postupe inovovania",
+    "description": "Link text for the deprecation notification."
+  },
+  "kmoo": {
+    "message": "Zachovať odhlásenie",
+    "description": "The title of the extension (without 'DEPRECATED')"
+  },
+  "message0": {
+    "message": "Rozšírenie $name$ bude o 14 dní odstránené.",
+    "description": "Body of the first deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  },
+  "message1": {
+    "message": "Rozšírenie $name$ bude onedlho odstránené.",
+    "description": "Body of the second deprecation message.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Keep My Opt-Outs"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add the Spanish translation in place of the missing Latin American Spanish translation.
The Hebrew locale was originally marked as HE, but now we use IW. Copy the IW directory to the HE directory to make sure that it won't stop working for users who installed it under HE locale.
Add the Slovak translation, which was missing.