### PR TITLE
Set the notification priority to maximum.

### DIFF
--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -150,6 +150,7 @@ Sunset.showNotification_ = function(index) {
       "title": extensionName,
       "message": chrome.i18n.getMessage("message" + index, extensionName),
       "buttons": [{"title": chrome.i18n.getMessage("learnmore")}],
+      "priority": 2
     }
   );
 


### PR DESCRIPTION
This makes the notification stay up for about a minute.