### PR TITLE
Remove the check for large notification index.

### DIFF
--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -114,8 +114,7 @@ Sunset.maybeShowNotification_ = function() {
     var index = parseInt(data.index, 10);
 
     // Reset the index if the stored data are invalid or not present.
-    if (isNaN(index) || index < 0 ||
-        index >= Sunset.timeline_offsets_.length) {
+    if (isNaN(index) || index < 0) {
       index = 0;
     }
 

--- a/chrome/test/chrome-api-shim.js
+++ b/chrome/test/chrome-api-shim.js
@@ -5,9 +5,10 @@ var chrome = {};
   var storage_ = {};
 
   function copy_dict(from, to) {
-    for (item in from)
+    for (item in from) {
       if (from.hasOwnProperty(item))
         to[item] = from[item];
+    }
   }
 
   chrome.storage = {};

--- a/chrome/test/chrome-api-shim.js
+++ b/chrome/test/chrome-api-shim.js
@@ -1,1 +1,60 @@
-// Shim various `chrome.*` APIs.
+var chrome = {};
+
+(function() {
+  /* chrome.storage */
+  var storage_ = {};
+
+  function copy_dict(from, to) {
+    for (item in from)
+      if (from.hasOwnProperty(item))
+        to[item] = from[item];
+  }
+
+  chrome.storage = {};
+  chrome.storage.sync = {
+    "set": function(dict, callback) {
+      copy_dict(dict, storage_);
+
+      if (callback)
+        callback();
+    },
+
+    "get": function(keys, callback) {
+      // We don't use keys anywhere.
+      var result = {};
+      copy_dict(storage_, result);
+      if (callback)
+        callback(result);
+    }
+  };
+
+  /* chrome.alarms */
+  var alarms_ = {};
+
+  chrome.alarms = {
+    "create": function(name, params, callback) {
+      alarms_[name] = params;
+      if (callback)
+        callback(alarms_[name]);
+    },
+
+    "get": function(name, callback) {
+      if (callback)
+        callback(alarms_[name]);
+    },
+
+   "clear": function(name, callback) {
+      delete alarms_[name];
+      if (callback)
+        callback();
+    }
+  };
+
+  /* chrome.i18n */
+  chrome.i18n = {};
+  chrome.i18n.getMessage = function() { return ""; };
+
+  /* chrome.notifications */
+  chrome.notifications = {};
+  chrome.notifications.create = function() {};
+})();


### PR DESCRIPTION
In shouldShowNotification_, we immediately return true for large indices. This is the correct behavior, since it allows us to try again if the extension uninstallation failed.

However, in maybeShowNotification_, we set the index to zero if it is out of range, which means that we reset the timeline. This CL removes the upper bound check in maybeShowNotification_, so that this doesn't happen.

To test that the whole process works, we add a mock of Chrome extension APIs.