### PR TITLE
Copy the timestamp from the synced storage to the local one as well.

### DIFF
--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -104,26 +104,49 @@ Sunset.shouldShowNotification_ = function(start, now, index) {
  * @private
  */
 Sunset.maybeShowNotification_ = function() {
-  chrome.storage.sync.get(null, function(data) {
-    // Populate the starting date with today's date if it isn't already set.
-    var starting_date = Date.parse(data.start) ? new Date(data.start) : new Date();
-    if (data.start != starting_date.toString())
-      chrome.storage.sync.set({ "start": starting_date.toString() });
+  chrome.storage.local.get(null, function(local_data) {
+    // Read the local storage timestamp.
+    var local_starting_date = Date.parse(local_data.start) ? new Date(local_data.start) : null;
 
-    // Read the index of the notification to be shown.
-    var index = parseInt(data.index, 10);
+    chrome.storage.sync.get(null, function(data) {
+      // Read the synced storage timestamp.
+      var starting_date = Date.parse(data.start) ? new Date(data.start) : null;
 
-    // Reset the index if the stored data are invalid or not present.
-    if (isNaN(index) || index < 0) {
-      index = 0;
-    }
+      // If the local storage is nonempty, but the sync storage is empty, it means
+      // that another synced instance has performed the uninstallation. Uninstall
+      // this instance immediately as well.
+      if (local_starting_date && !starting_date)
+        chrome.management.uninstallSelf();
 
-    // Trigger notification if we have reached the date suggested
-    // by the timeline. This check is not required for the first notification.
-    var now = new Date();
+      // Populate the starting date with today's date if it isn't already set.
+      if (!starting_date)
+        starting_date = new Date();
 
-    if (Sunset.shouldShowNotification_(starting_date, now, index))
-      Sunset.showNotification_(index);
+      // The date we write to the local storage should be the same as the one
+      // in the synced storage.
+      local_starting_date = starting_date;
+
+      // Update both storages.
+      if (data.start != starting_date.toString())
+        chrome.storage.sync.set({ "start": starting_date.toString() });
+      if (local_data.start != local_starting_date.toString())
+        chrome.storage.local.set({ "start": local_starting_date.toString() });
+
+      // Read the index of the notification to be shown.
+      var index = parseInt(data.index, 10);
+
+      // Reset the index if the stored data are invalid or not present.
+      if (isNaN(index) || index < 0) {
+        index = 0;
+      }
+
+      // Trigger notification if we have reached the date suggested
+      // by the timeline. This check is not required for the first notification.
+      var now = new Date();
+
+      if (Sunset.shouldShowNotification_(starting_date, now, index))
+        Sunset.showNotification_(index);
+    });
   });
 };
 

--- a/chrome/sunset.js
+++ b/chrome/sunset.js
@@ -107,33 +107,35 @@ Sunset.maybeShowNotification_ = function() {
   chrome.storage.local.get(null, function(local_data) {
     // Read the local storage timestamp.
     var local_starting_date = Date.parse(local_data.start) ? new Date(local_data.start) : null;
+    console.log(local_data);
 
-    chrome.storage.sync.get(null, function(data) {
+    chrome.storage.sync.get(null, function(synced_data) {
+      console.log(synced_data);
       // Read the synced storage timestamp.
-      var starting_date = Date.parse(data.start) ? new Date(data.start) : null;
+      var synced_starting_date = Date.parse(synced_data.start) ? new Date(synced_data.start) : null;
 
       // If the local storage is nonempty, but the sync storage is empty, it means
       // that another synced instance has performed the uninstallation. Uninstall
       // this instance immediately as well.
-      if (local_starting_date && !starting_date)
+      if (local_starting_date && !synced_starting_date)
         chrome.management.uninstallSelf();
 
       // Populate the starting date with today's date if it isn't already set.
-      if (!starting_date)
-        starting_date = new Date();
+      if (!synced_starting_date)
+        synced_starting_date = new Date();
 
       // The date we write to the local storage should be the same as the one
       // in the synced storage.
-      local_starting_date = starting_date;
+      local_starting_date = synced_starting_date;
 
       // Update both storages.
-      if (data.start != starting_date.toString())
-        chrome.storage.sync.set({ "start": starting_date.toString() });
+      if (synced_data.start != synced_starting_date.toString())
+        chrome.storage.sync.set({ "start": synced_starting_date.toString() });
       if (local_data.start != local_starting_date.toString())
         chrome.storage.local.set({ "start": local_starting_date.toString() });
 
       // Read the index of the notification to be shown.
-      var index = parseInt(data.index, 10);
+      var index = parseInt(synced_data.index, 10);
 
       // Reset the index if the stored data are invalid or not present.
       if (isNaN(index) || index < 0) {
@@ -144,7 +146,7 @@ Sunset.maybeShowNotification_ = function() {
       // by the timeline. This check is not required for the first notification.
       var now = new Date();
 
-      if (Sunset.shouldShowNotification_(starting_date, now, index))
+      if (Sunset.shouldShowNotification_(synced_starting_date, now, index))
         Sunset.showNotification_(index);
     });
   });

--- a/chrome/test/chrome-api-shim.js
+++ b/chrome/test/chrome-api-shim.js
@@ -82,4 +82,7 @@ var chrome = {};
   chrome.testUtils.wasUninstalled = function() {
     return uninstalled_;
   }
+  chrome.testUtils.reinstall = function() {
+    uninstalled_ = false;
+  }
 })();

--- a/chrome/test/chrome-api-shim.js
+++ b/chrome/test/chrome-api-shim.js
@@ -11,23 +11,30 @@ var chrome = {};
 
   chrome.storage = {};
   function Storage() {
-    var storage_ = {};
+    this.storage_ = {};
+  }
 
-    this.set = function(dict, callback) {
-      copy_dict(dict, storage_);
+  Storage.prototype.set = function(dict, callback) {
+    copy_dict(dict, this.storage_);
 
-      if (callback)
-        callback();
-    };
-
-    this.get = function(keys, callback) {
-      // We don't use keys anywhere.
-      var result = {};
-      copy_dict(storage_, result);
-      if (callback)
-        callback(result);
-    }
+    if (callback)
+      callback();
   };
+
+  Storage.prototype.get = function(keys, callback) {
+    // We don't use keys anywhere.
+    var result = {};
+    copy_dict(this.storage_, result);
+    if (callback)
+      callback(result);
+  };
+
+  Storage.prototype.clear = function(callback) {
+    this.storage_ = {};
+    if (callback)
+      callback();
+  };
+
   chrome.storage.sync = new Storage();
   chrome.storage.local = new Storage();
 

--- a/chrome/test/chrome-api-shim.js
+++ b/chrome/test/chrome-api-shim.js
@@ -2,8 +2,6 @@ var chrome = {};
 
 (function() {
   /* chrome.storage */
-  var storage_ = {};
-
   function copy_dict(from, to) {
     for (item in from) {
       if (from.hasOwnProperty(item))
@@ -12,15 +10,17 @@ var chrome = {};
   }
 
   chrome.storage = {};
-  chrome.storage.sync = {
-    "set": function(dict, callback) {
+  function Storage() {
+    var storage_ = {};
+
+    this.set = function(dict, callback) {
       copy_dict(dict, storage_);
 
       if (callback)
         callback();
-    },
+    };
 
-    "get": function(keys, callback) {
+    this.get = function(keys, callback) {
       // We don't use keys anywhere.
       var result = {};
       copy_dict(storage_, result);
@@ -28,6 +28,8 @@ var chrome = {};
         callback(result);
     }
   };
+  chrome.storage.sync = new Storage();
+  chrome.storage.local = new Storage();
 
   /* chrome.alarms */
   var alarms_ = {};
@@ -58,4 +60,19 @@ var chrome = {};
   /* chrome.notifications */
   chrome.notifications = {};
   chrome.notifications.create = function() {};
+
+  /* chrome.management */
+  var uninstalled_ = false;
+
+  chrome.management = {};
+  chrome.management.uninstallSelf = function() {
+    uninstalled_ = true;
+  };
+
+  /* chrome.testUtils */
+  /* Our test utils - not a real Chrome API */
+  chrome.testUtils = {};
+  chrome.testUtils.wasUninstalled = function() {
+    return uninstalled_;
+  }
 })();

--- a/chrome/test/sunset-test.js
+++ b/chrome/test/sunset-test.js
@@ -85,21 +85,25 @@ test(function () {
 
 test(function () {
   // Try different configurations of local and storage data.
-  for (var local = false; local < true; local++)
-    for (var synced = false; synced < true; synced++) {
-      local_data = local ? { "start": new Date() } : {};
-      synced_data = synced ? { "start": new Date() } : {};
+  for (var local = 1; local <= 1; local++)
+    for (var synced = 1; synced <= 1; synced++) {
+      local_data = !!local ? { "start": (new Date()).toString() } : {};
+      synced_data = !!synced ? { "start": (new Date()).toString() } : {};
 
-      chrome.storage.local.set(local_data, function() {
-        chrome.storage.sync.set(synced_data, function() {
-          Sunset.maybeShowNotification_();
+      chrome.storage.local.clear(function() {
+        chrome.storage.sync.clear(function() {
+          chrome.storage.local.set(local_data, function() {
+            chrome.storage.sync.set(synced_data, function() {
+              Sunset.maybeShowNotification_();
+            });
+          });
         });
       });
 
       // When local storage is non-empty and the synced storage is empty,
       // the extension should uninstall itself. Otherwise, it must remain
       // installed.
-      assert_equals(chrome.testUtils.wasUninstalled(), local && !synced);
+      assert_equals(chrome.testUtils.wasUninstalled(), !!local && !synced);
 
       // The starting dates in the local storage and synced storage should
       // be always the same.

--- a/chrome/test/sunset-test.js
+++ b/chrome/test/sunset-test.js
@@ -85,10 +85,12 @@ test(function () {
 
 test(function () {
   // Try different configurations of local and storage data.
-  for (var local = 1; local <= 1; local++)
-    for (var synced = 1; synced <= 1; synced++) {
+  for (var local = 0; local <= 1; local++)
+    for (var synced = 0; synced <= 1; synced++) {
       local_data = !!local ? { "start": (new Date()).toString() } : {};
       synced_data = !!synced ? { "start": (new Date()).toString() } : {};
+
+      chrome.testUtils.reinstall();
 
       chrome.storage.local.clear(function() {
         chrome.storage.sync.clear(function() {


### PR DESCRIPTION
To differentiate between a fresh installation (empty local storage) and a state when this extension was woken up after missing a synced uninstallation request (non-empty local storage). In the latter case, we uninstall the extension immediately.

Note that no timestamp is actually needed; in the local storage, we only actually need a boolean flag. However, the timestamp is added for consistency, for compliance with the agreed specification, and for possible future purposes (if this fix was not enough to cope with the syncing bug).